### PR TITLE
Add support for Python 3

### DIFF
--- a/pyramid_celery/__init__.py
+++ b/pyramid_celery/__init__.py
@@ -47,7 +47,7 @@ def convert_celery_options(config):
     Converts celery options to apropriate types
     """
 
-    for key, value in config.iteritems():
+    for key, value in config.items():
         opt_type = OPTIONS.get(key)
         if opt_type:
             if opt_type[0] == str:


### PR DESCRIPTION
Use dict.items() instead of dict.iteritems() to support Python 3.

Ref: https://github.com/niteoweb/ebn/issues/3275